### PR TITLE
Jvr/9

### DIFF
--- a/SOURCES/0001-Fix-calloc-call.patch
+++ b/SOURCES/0001-Fix-calloc-call.patch
@@ -1,0 +1,28 @@
+From 70d895098eaa0de97b6db6d06c990fe82bf59b91 Mon Sep 17 00:00:00 2001
+From: Yann Dirson <yann.dirson@vates.tech>
+Date: Wed, 6 Nov 2024 10:34:37 +0100
+Subject: [PATCH] Fix calloc call
+
+Newer gcc issues a warning for swapped arguments, and we use -Werror
+
+Signed-off-by: Yann Dirson <yann.dirson@vates.tech>
+---
+ src/arg-list.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/arg-list.c b/src/arg-list.c
+index b19f3cc..df39819 100644
+--- a/src/arg-list.c
++++ b/src/arg-list.c
+@@ -27,7 +27,7 @@
+ // =============================================================================
+ 
+ static inline ArgNode *arg_list_create_node () {
+-  ArgNode *node = calloc(sizeof *node, 1);
++  ArgNode *node = calloc(1, sizeof *node);
+   if (!node)
+     syslog(LOG_ERR, "Unable to alloc list node.");
+   return node;
+-- 
+2.39.5
+

--- a/SOURCES/0002-Add-support-for-mem_pnode-argument.patch
+++ b/SOURCES/0002-Add-support-for-mem_pnode-argument.patch
@@ -1,0 +1,59 @@
+From 6119ebe993d7da2111d3d4f71b232de7feacecea Mon Sep 17 00:00:00 2001
+From: Julian Vetter <julian.vetter@vates.tech>
+Date: Fri, 12 Jun 2026 15:19:53 +0200
+Subject: [PATCH] Add support for --mem_pnode argument
+
+xenopsd now passes --mem_pnode to emu-manager to specify the NUMA node
+for memory placement. Without this, emu-manager rejects the argument
+with "Unknown option" and aborts, causing VM resume and migration to
+fail.
+
+Signed-off-by: Julian Vetter <julian.vetter@vates.tech>
+---
+ src/main.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/main.c b/src/main.c
+index 6fb089e..5a784ed 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -67,6 +67,7 @@ static void usage (const char *progname) {
+   puts("  --controloutfd           control output descriptor");
+   puts("  --store_port             store port");
+   puts("  --console_port           console port");
++  puts("  --mem_pnode              NUMA node for memory placement");
+   puts("  --live                   enable live migration");
+   puts("  --mode                   migration mode");
+   puts("  --dm                     device model");
+@@ -113,6 +114,7 @@ static void set_crash_handler (XcpCrashHandler handler) {
+ #define MAIN_OPT_DEBUG 1
+ #define MAIN_OPT_DEVICE_MODEL 2
+ #define MAIN_OPT_FORK 3
++#define MAIN_OPT_MEM_PNODE 4
+ 
+ int main (int argc, char *argv[]) {
+   openlog(argv[0], LOG_PID, LOG_USER | LOG_MAIL);
+@@ -129,6 +131,7 @@ int main (int argc, char *argv[]) {
+     { "mode", 1, NULL, 'm' },
+     { "dm", 1, NULL, MAIN_OPT_DEVICE_MODEL },
+     { "fork", 1, NULL, MAIN_OPT_FORK },
++    { "mem_pnode", 1, NULL, MAIN_OPT_MEM_PNODE },
+     { "debug", 0, NULL, MAIN_OPT_DEBUG },
+     { "help", 0, NULL, 'h' },
+     { NULL, 0, 0, 0 }
+@@ -204,6 +207,12 @@ int main (int argc, char *argv[]) {
+           return EXIT_FAILURE;
+         }
+         break;
++      case MAIN_OPT_MEM_PNODE:
++        if (arg_list_append_str(&xenguestEmu->arguments, "mem_pnode", optarg) < 0) {
++          syslog(LOG_ERR, "Failed to add mem_pnode argument: `%s`.", strerror(errno));
++          return EXIT_FAILURE;
++        }
++        break;
+       case 'l':
+         if (!strcmp(optarg, "true"))
+           live = true;
+-- 
+2.53.0
+

--- a/SPECS/emu-manager.spec
+++ b/SPECS/emu-manager.spec
@@ -4,12 +4,13 @@
 
 Name:           xcp-emu-manager
 Version:        1.2.0
-Release:        2.0.ydi.1%{?dist}
+Release:        3.0.ydi.1%{?dist}
 Summary:        Tool used for managing xenguest
 License:        GPLv3
 URL:            https://github.com/xcp-ng/xcp-emu-manager
 Source0:        https://github.com/xcp-ng/xcp-emu-manager/archive/v%{version}/%{name}-%{version}.tar.gz
 Patch1: 0001-Fix-calloc-call.patch
+Patch2: 0002-Add-support-for-mem_pnode-argument.patch
 
 BuildRequires:  cmake3
 BuildRequires:  make
@@ -44,6 +45,9 @@ cd %{_vpath_builddir}
 %{_libdir}/xen/bin/emu-manager
 
 %changelog
+* Fri Jun 12 2026 Julian Vetter <julian.vetter@vates.tech> - 1.2.0-3.0.ydi.1
+- Add support for --mem_pnode argument passed by xenopsd for NUMA memory placement
+
 * Mon Jun 30 2025 Yann Dirson <yann.dirson@vates.tech> - 1.2.0-2.0.ydi.1
 - Fix build with recent gcc
 

--- a/SPECS/emu-manager.spec
+++ b/SPECS/emu-manager.spec
@@ -4,11 +4,12 @@
 
 Name:           xcp-emu-manager
 Version:        1.2.0
-Release:        2%{?dist}
+Release:        2.0.ydi.1%{?dist}
 Summary:        Tool used for managing xenguest
 License:        GPLv3
 URL:            https://github.com/xcp-ng/xcp-emu-manager
 Source0:        https://github.com/xcp-ng/xcp-emu-manager/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch1: 0001-Fix-calloc-call.patch
 
 BuildRequires:  cmake3
 BuildRequires:  make
@@ -43,6 +44,9 @@ cd %{_vpath_builddir}
 %{_libdir}/xen/bin/emu-manager
 
 %changelog
+* Mon Jun 30 2025 Yann Dirson <yann.dirson@vates.tech> - 1.2.0-2.0.ydi.1
+- Fix build with recent gcc
+
 * Tue Jan 21 2025 Thierry Escande <thierry.escande@vates.tech> - 1.2.0-2
 - Fix build that was failing because of cmake3 update
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

N/A

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Fix build for xcp-ng 9. There is a new argument that emu-manager needs to understand for NUMA memory placement. So, add it.

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

xcp-ng 9.

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Nothing to see here. There is just a new argument for NUMA memory placement. That is passed to emu-manager.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->


<!-- Add links to the documentation update PRs if/when they are created. -->

N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

ANSWER

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

I manually ran the `tests/misc/test_vm_basic_operations.py` and it passed, after it had failed before in a `VM resume` because emu-manager would directly terminate (not knowing what to do with the new `--mem_pnode` argument).

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

It's fully covered by the xcp-ng-tests test suite.

#### What tests have been or will be added to CI for this change? If none, explain why.

None. It's already being tested by the `test_vm_basic_operations.py` test.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
